### PR TITLE
Fix readTrace()

### DIFF
--- a/Utilities/repeatUtil/repeatUtilities.c
+++ b/Utilities/repeatUtil/repeatUtilities.c
@@ -175,30 +175,29 @@ void readSubsetTree(fileMetadata* curFile, char* ptrPath)
     }
 }
 
+#define MAX_LINE_LENGTH 1000
 
 void readTrace(fileMetadata* curFile, char* tracePath)
 {
     FILE* traceFPTR = getSysData()->functions->real_fopen(tracePath, "r");  
     CallList* newCall;
-    char* tmp;
-    char c[1000];
-    char* token;
-    while(fgets(c,sizeof c, traceFPTR)!= NULL) /* read a line from a file */ 
+
+    char line[MAX_LINE_LENGTH];
+    while(fgets(line, MAX_LINE_LENGTH, traceFPTR)!= NULL) /* read a line from a file */ 
     {
         newCall = malloc(sizeof(CallList));
-        char* ret = strrchr(c, ':');
+        char* ret = strrchr(line, ':');
         memcpy(newCall->hash, ret+1, HASH_LEN);
         newCall->hash[HASH_LEN] = 0;
-        token = strtok(c, ":");
-        newCall->type = getType(token);
-        token = strtok(NULL, c);
-        char* tmp = malloc(HASH_LEN);
-        sscanf(token, "%ld:%ld:%ld:%d:%s\n", &newCall->timeStamp, &newCall->offset, &newCall->size, &newCall->other,tmp);
-        free(tmp);
-        memset(c, '\0', sizeof(c));
+      
+        newCall->type = getType(strtok(line, ":"));
+        newCall->timeStamp = atol(strtok(NULL, ":"));
+        newCall->offset = atol(strtok(NULL, ":"));
+        newCall->size = atol(strtok(NULL, ":"));
+        newCall->other = atol(strtok(NULL, ":"));
+
         addCall(curFile, newCall);
-    }
-   
+    }   
 }
 
 enum CallType getType(char* call)


### PR DESCRIPTION
Prashant reported an error:

> for big real life notebooks it fails to reexecute. giving the following error.
> 
> Size doesn't match
> Offset doesn't match
> Timestamps don't match
> Others don't match
> Hashes don't match
> Size doesn't match
> Timestamps don't match
> Others don't match
> Size doesn't match
> Offset doesn't match
> Hashes don't match
> Types don't match
> Size doesn't match
> Offset doesn't match
> Hashes don't match
> Segmentation fault (core dumped)

This is caused by a problem in readTrace() due to the wrong use of strtok().