### PR TITLE
Fix ReExecute Wrapper return value of lseek64()

### DIFF
--- a/ReExecute/repeatLibrary.c
+++ b/ReExecute/repeatLibrary.c
@@ -272,6 +272,7 @@ size_t logRead(off_t offset, size_t readSize, FILE *fptr, int fd, enum CallType 
         strcat(call->hash,tmp);
     }
     compareCalls(metadata, call);
+    metadata->filePointer += readSize;
     return 0;
 }
 
@@ -310,7 +311,7 @@ void addOpenFile(int fd, FILE *fptr, char *path)
 /// @param fd File desc of the file have to supply either fd or fptr
 /// @param whence mode for the seek SET/CUR/END
 /// @param type an Enumeration of what type of open call was made
-void logSeek(long off, FILE* fptr, int fd, int whence, enum CallType type)
+off_t logSeek(long off, FILE* fptr, int fd, int whence, enum CallType type)
 {
 
     fileMetadata* metadata = getMetadata(fptr, fd);
@@ -334,6 +335,7 @@ void logSeek(long off, FILE* fptr, int fd, int whence, enum CallType type)
         // TODO
     }
 
+    return metadata->filePointer;
 }
 
 

--- a/ReExecute/repeatLibrary.h
+++ b/ReExecute/repeatLibrary.h
@@ -67,7 +67,7 @@ void logWrite(off_t offset, size_t wrtteSize, FILE *fptr, int fd, enum CallType 
 /// @param fd File desc of the file have to supply either fd or fptr
 /// @param whence mode for the seek SET/CUR/END
 /// @param type an Enumeration of what type of open call was made
-void logSeek(long off, FILE *fptr, int fd, int whence, enum CallType tpye);
+off_t logSeek(long off, FILE *fptr, int fd, int whence, enum CallType tpye);
 
 
 /// @brief Log a stat call for given fd

--- a/ReExecute/wrappers.c
+++ b/ReExecute/wrappers.c
@@ -180,8 +180,7 @@ off_t lseek64(int fildes, off_t offset, int whence)
 {
     if(checkTrackingDesc(fildes))
     {
-        logSeek(offset, NULL, fildes, whence, LSEEK64);    
-        return 0;
+        return logSeek(offset, NULL, fildes, whence, LSEEK64);    
     }
     else
     {


### PR DESCRIPTION
The repeat library logSeek() always returns 0, which is acceptable only if the caller to lseek() does not use the return value or if lseek() offset is zero.

A similar problem may happen in other File I/O functions that return zero instead of the expected return value by the caller.